### PR TITLE
Adding Circular Buffer [DRAFT] 

### DIFF
--- a/data-structures/circular_buffer/CMakeLists.txt
+++ b/data-structures/circular_buffer/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(circular_buffer circular_buffer.cpp)
+
+target_include_directories(circular_buffer PUBLIC include)

--- a/data-structures/circular_buffer/circular_buffer.cpp
+++ b/data-structures/circular_buffer/circular_buffer.cpp
@@ -1,0 +1,1 @@
+#include <circular_buffer/circular_buffer.h>

--- a/data-structures/circular_buffer/include/circular_buffer/circular_buffer.h
+++ b/data-structures/circular_buffer/include/circular_buffer/circular_buffer.h
@@ -1,0 +1,50 @@
+#ifndef CIRCULAR_BUFFER_H
+#define CIRCULAR_BUFFER_H
+
+#include <vector>
+#include <optional>
+
+namespace buffers
+{
+    template <typename T>
+    class CircularBuffer
+    {
+    public:
+        explicit CircularBuffer(std::size_t n)
+          : _buffer(n), _start{0}, _end{0}
+        {
+        }
+        
+        bool write(T const& value)
+        {
+            if (_start == _end)
+            {
+                return false;
+            }
+
+            _buffer[_end] = value;
+            _end = (_end + 1) % _buffer.size();
+            return true;
+        }
+
+        std::optional<T> read()
+        {
+            if (_start == _end)
+            {
+                return std::nullopt;
+            }
+
+            // this makes this non-thread-safe!
+            auto const ret_position = _start;
+            _start = (_start + 1) % _buffer.size();
+            return _buffer[ret_position];
+        }
+
+    private:    
+        std::vector<T> _buffer;
+        std::size_t _start; // points to first element
+        std::size_t _end; // means position after last
+    };
+} // namespace buffers
+
+#endif // CIRCULAR_BUFFER_H


### PR DESCRIPTION
Adding a [circular buffer](https://en.wikipedia.org/wiki/Circular_buffer) to the data structures. It's just a work in progress structure at the moment, I think it requires a few more things:

1. Rethink the API, perhaps modernise with some other helper functions like `write_many(...)` functions.
2. Make it a little more thread-safe.
3. Write loads of tests to make sure it actually work.

For the tests @johnspeny , I'd recommend GoogleTests! I took a look at how you include third-party libs and it's ok for now, it works. However, you can probably either get them as submodules (so your repo is not tracking their code), with CMake `FetchContent*` functions, or with a package manager. I can help you with that whenever I'm free.